### PR TITLE
Updated django-rest-framework version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.9,<1.11
-djangorestframework>=3.3,<3.6
+djangorestframework>=3.3,<3.7
 django-model-utils
 netdiff>=0.4.7,<=5.0
 jsonfield


### PR DESCRIPTION
Fixes #17 
3.6.2 seems to be the latest version and all the tests seem to run perfectly.