### PR TITLE
[WIP] Add a read only URL field when the strategy is receive

### DIFF
--- a/django_netjsongraph/static/netjsongraph/admin.css
+++ b/django_netjsongraph/static/netjsongraph/admin.css
@@ -1,0 +1,8 @@
+input[type=text].readonly{
+    border: 1px solid rgba(0, 0, 0, 0.05) !important;
+    background-color: rgba(0, 0, 0, 0.070);
+}
+
+#id_receive_url{
+    width: 435px
+}

--- a/django_netjsongraph/static/netjsongraph/receive-url.js
+++ b/django_netjsongraph/static/netjsongraph/receive-url.js
@@ -1,0 +1,9 @@
+django.jQuery(function($) {
+    var p = $('.field-receive_url p, .field-receive_url > div > div'),
+        value = window.location.origin + p.text();
+    p.html('<input readonly id="id_receive_url" type="text" class="vTextField readonly" value="'+ value +'">');
+    var field = $('#id_receive_url');
+    field.click(function(){
+        $(this).select();
+    });
+});

--- a/django_netjsongraph/templates/admin/django_netjsongraph/topology/change_form.html
+++ b/django_netjsongraph/templates/admin/django_netjsongraph/topology/change_form.html
@@ -7,7 +7,7 @@
             $(document).ready(function() {
                 var strategy = $('#id_strategy'),
                     fetch_rows = $('#id_url').parents('.form-row'),
-                    receive_rows = $('#id_key, #id_expiration_time').parents('.form-row');
+                    receive_rows = $('#id_key, #id_expiration_time, #id_receive_url').parents('.form-row');
                 strategy.change(function(e){
                     if (strategy.val() == 'fetch'){
                         fetch_rows.show();

--- a/django_netjsongraph/tests/test_admin.py
+++ b/django_netjsongraph/tests/test_admin.py
@@ -85,6 +85,15 @@ class TestAdmin(TestCase, LoadMixin):
         self.assertContains(response, 'View on site')
         self.assertContains(response, t.get_absolute_url())
 
+    def test_topology_receive_url(self):
+        t = Topology.objects.first()
+        t.strategy = 'receive'
+        t.save()
+        path = reverse('admin:django_netjsongraph_topology_change', args=[t.pk])
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'field-receive_url')
+
     def test_node_change_form(self):
         n = Node.objects.first()
         path = reverse('admin:django_netjsongraph_node_change', args=[n.pk])


### PR DESCRIPTION
References #9.This PR has a lot more work to do. As of now, I only followed the instructions given in #9 comments. There is a problem with my understanding of read only fields in django admin. Here are my doubts:
  - The read only field doesn't appear in the admin site as of now. Does a HTML element automatically get created with `id = id_<parameter>`? This is what I was able to make out checking the code.
  - And regarding the js file similar to uuid.js in django_netjsonconfig, I made some changes accordingly but I'm not so clear about it.

@nemesisdesign Please review and study material suggestions are requested.