### PR TITLE
[visualizer] Added base classes to improve reusability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,41 @@ If you are not making drastic changes to the api views, you can avoid duplicatin
 
     urlpatterns = get_api_urls(views)
 
+Extending Visualizer Views
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+If your use case doesn't vary much from the base, you may also want to try to reuse the Visualizer views:
+
+.. code-block:: python
+
+    # your app.visualizer.views
+    from ..models import Topology
+    from .generics import BaseTopologyDetailView, BaseTopologyListView
+
+
+    class TopologyListView(BaseTopologyListView):
+        topology_model = Topology
+
+
+    class TopologyDetailView(BaseTopologyDetailView):
+        topology_model = Topology
+
+
+    topology_list = TopologyListView.as_view()
+    topology_detail = TopologyDetailView.as_view()
+
+
+Visualizer URLs
+^^^^^^^^^^^^^^^
+If you are not making any drastic changes to visualizer views, you can avoid duplicating the URL logic by using ``get_visualizer_urls`` function. Put this in your visualizer ``urls.py``
+
+.. code-block:: python
+
+    # your app.visualizer.urls
+    from django_netjsongraph.utils import get_visualizer_urls
+    from . import views
+
+    urlpatterns = get_visualizer_urls(views)
+
 Extending AppConfig
 ^^^^^^^^^^^^^^^^^^^
 

--- a/django_netjsongraph/utils.py
+++ b/django_netjsongraph/utils.py
@@ -53,3 +53,18 @@ def get_api_urls(views_module):
             name='receive_topology'),
     ]
     return urls
+
+
+def get_visualizer_urls(views_module):
+    """
+    used by third party apps to reduce boilerplate
+    """
+    urls = [
+        url(r'^$',
+            views_module.topology_list,
+            name='topology_list'),
+        url(r'^topology/(?P<pk>[^/]+)/$',
+            views_module.topology_detail,
+            name='topology_detail'),
+    ]
+    return urls

--- a/django_netjsongraph/visualizer/generics.py
+++ b/django_netjsongraph/visualizer/generics.py
@@ -1,0 +1,26 @@
+from django.shortcuts import render_to_response
+
+from ..settings import VISUALIZER_CSS
+from ..utils import get_object_or_404
+
+try:
+    from django.views import View
+except:
+    # Support to django<1.10
+    from django.views.generic import View
+
+
+class BaseTopologyListView(View):
+    def get(self, request):
+        topologies = self.topology_model.objects.filter(published=True)
+        return render_to_response('netjsongraph/list.html',
+                                  {'topologies': topologies,
+                                   'VISUALIZER_CSS': VISUALIZER_CSS})
+
+
+class BaseTopologyDetailView(View):
+    def get(self, request, pk):
+        topology = get_object_or_404(self.topology_model, pk)
+        return render_to_response('netjsongraph/detail.html',
+                                  {'topology': topology,
+                                   'VISUALIZER_CSS': VISUALIZER_CSS})

--- a/django_netjsongraph/visualizer/urls.py
+++ b/django_netjsongraph/visualizer/urls.py
@@ -1,8 +1,4 @@
-from django.conf.urls import url
-
 from . import views
+from ..utils import get_visualizer_urls
 
-urlpatterns = [
-    url(r'^$', views.topology_list, name='topology_list'),
-    url(r'^topology/(?P<pk>[^/]+)/$', views.topology_detail, name='topology_detail'),
-]
+urlpatterns = get_visualizer_urls(views)

--- a/django_netjsongraph/visualizer/views.py
+++ b/django_netjsongraph/visualizer/views.py
@@ -1,19 +1,14 @@
-from django.shortcuts import render_to_response
-
 from ..models import Topology
-from ..settings import VISUALIZER_CSS
-from ..utils import get_object_or_404
+from .generics import BaseTopologyDetailView, BaseTopologyListView
 
 
-def topology_list(request):
-    topologies = Topology.objects.filter(published=True)
-    return render_to_response('netjsongraph/list.html',
-                              {'topologies': topologies,
-                               'VISUALIZER_CSS': VISUALIZER_CSS})
+class TopologyListView(BaseTopologyListView):
+    topology_model = Topology
 
 
-def topology_detail(request, pk):
-    topology = get_object_or_404(Topology, pk)
-    return render_to_response('netjsongraph/detail.html',
-                              {'topology': topology,
-                               'VISUALIZER_CSS': VISUALIZER_CSS})
+class TopologyDetailView(BaseTopologyDetailView):
+    topology_model = Topology
+
+
+topology_list = TopologyListView.as_view()
+topology_detail = TopologyDetailView.as_view()


### PR DESCRIPTION
This is to make the views of visualizer reusable. In order to integrate it with openwisp-network-topology. The issue of which can be looked at https://github.com/openwisp/openwisp-network-topology/issues/6